### PR TITLE
Update providers and change to smallest gen2 sku size

### DIFF
--- a/application-gateway/provider.tf
+++ b/application-gateway/provider.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+  }
 }

--- a/autoscaling/provider.tf
+++ b/autoscaling/provider.tf
@@ -1,13 +1,14 @@
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      version = "~> 3.0"
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
     }
   }
 }
 
-
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+  }
 }

--- a/azure-ad/main.tf
+++ b/azure-ad/main.tf
@@ -1,7 +1,24 @@
-provider "azuread" {
-  version = "=0.7"
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 2.41.0"
+    }
+  }
 }
 
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  version = "=1.35.0"
+  features {
+  }
+}
+
+# Configure the Azure Active Directory Provider
+provider "azuread" {
+  features {
+  }
 }

--- a/blob-storage/instance.tf
+++ b/blob-storage/instance.tf
@@ -4,7 +4,7 @@ resource "azurerm_virtual_machine" "demo-instance" {
   location              = var.location
   resource_group_name   = azurerm_resource_group.demo.name
   network_interface_ids = ["${azurerm_network_interface.demo-instance.id}"]
-  vm_size               = "Standard_A1_v2"
+  vm_size               = "Standard_DC1s_v2"
 
   # this is a demo instance, so we can delete all data on termination
   delete_os_disk_on_termination    = true
@@ -16,21 +16,24 @@ resource "azurerm_virtual_machine" "demo-instance" {
 
   storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
     version   = "latest"
   }
+
   storage_os_disk {
     name              = "myosdisk1"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
   }
+
   os_profile {
     computer_name  = "demo-instance"
     admin_username = "demo"
     #admin_password = "..."
   }
+
   os_profile_linux_config {
     disable_password_authentication = true
     ssh_keys {
@@ -38,7 +41,6 @@ resource "azurerm_virtual_machine" "demo-instance" {
       path     = "/home/demo/.ssh/authorized_keys"
     }
   }
-
 }
 
 resource "azurerm_network_interface" "demo-instance" {

--- a/blob-storage/main.tf
+++ b/blob-storage/main.tf
@@ -1,5 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  version = "=1.35.0"
+  features {
+  }
 }
 
 # Create a resource group

--- a/conditionals/main.tf
+++ b/conditionals/main.tf
@@ -1,5 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  version = "=1.35.0"
+  features {
+  }
 }
 
 # Create a resource group

--- a/database-cosmosdb/instance.tf
+++ b/database-cosmosdb/instance.tf
@@ -4,7 +4,7 @@ resource "azurerm_virtual_machine" "demo-instance" {
   location              = var.location
   resource_group_name   = azurerm_resource_group.demo.name
   network_interface_ids = ["${azurerm_network_interface.demo-instance.id}"]
-  vm_size               = "Standard_A1_v2"
+  vm_size               = "Standard_DC1s_v2"
 
   # this is a demo instance, so we can delete all data on termination
   delete_os_disk_on_termination    = true
@@ -12,21 +12,24 @@ resource "azurerm_virtual_machine" "demo-instance" {
 
   storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "18.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
     version   = "latest"
   }
+
   storage_os_disk {
     name              = "myosdisk1"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
   }
+
   os_profile {
     computer_name  = "demo-instance"
     admin_username = "demo"
     #admin_password = "..."
   }
+
   os_profile_linux_config {
     disable_password_authentication = true
     ssh_keys {

--- a/database-cosmosdb/main.tf
+++ b/database-cosmosdb/main.tf
@@ -1,5 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+  }
 }
 
 # Create a resource group

--- a/database-mssql/instance.tf
+++ b/database-mssql/instance.tf
@@ -3,15 +3,15 @@ resource "azurerm_linux_virtual_machine" "demo-instance" {
   location              = var.location
   resource_group_name   = azurerm_resource_group.demo.name
   network_interface_ids = ["${azurerm_network_interface.demo-instance.id}"]
-  size                  = "Standard_A1_v2"
+  vm_size               = "Standard_DC1s_v2"
 
   disable_password_authentication = true  # change to false if you want to use a password instead of ssh key
   #admin_password                 = "..."
 
-  source_image_reference {
+  storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "18.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
     version   = "latest"
   }
 
@@ -29,7 +29,6 @@ resource "azurerm_linux_virtual_machine" "demo-instance" {
     public_key = file("mykey.pub")
   }
 }
-
 
 resource "azurerm_network_interface" "demo-instance" {
   name                      = "${var.prefix}-instance1"

--- a/database-mssql/main.tf
+++ b/database-mssql/main.tf
@@ -1,5 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+  }
 }
 
 # Create a resource group

--- a/database-mysql/instance.tf
+++ b/database-mysql/instance.tf
@@ -4,7 +4,7 @@ resource "azurerm_virtual_machine" "demo-instance" {
   location              = var.location
   resource_group_name   = azurerm_resource_group.demo.name
   network_interface_ids = ["${azurerm_network_interface.demo-instance.id}"]
-  vm_size               = "Standard_A1_v2"
+  vm_size               = "Standard_DC1s_v2"
 
   # this is a demo instance, so we can delete all data on termination
   delete_os_disk_on_termination = true
@@ -12,21 +12,24 @@ resource "azurerm_virtual_machine" "demo-instance" {
 
   storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
     version   = "latest"
   }
+
   storage_os_disk {
     name              = "myosdisk1"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
   }
+
   os_profile {
     computer_name  = "demo-instance"
     admin_username = "demo"
     #admin_password = "..."
   }
+
   os_profile_linux_config {
     disable_password_authentication = true
     ssh_keys {

--- a/database-mysql/main.tf
+++ b/database-mysql/main.tf
@@ -1,14 +1,16 @@
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      version = "3.1.0"
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
     }
   }
 }
 
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+  }
 }
 
 # Create a resource group

--- a/first-steps/instance.tf
+++ b/first-steps/instance.tf
@@ -4,7 +4,7 @@ resource "azurerm_virtual_machine" "demo-instance" {
   location              = var.location
   resource_group_name   = azurerm_resource_group.demo.name
   network_interface_ids = [azurerm_network_interface.demo-instance.id]
-  vm_size               = "Standard_A1_v2"
+  vm_size               = "Standard_DC1s_v2"
 
   # this is a demo instance, so we can delete all data on termination
   delete_os_disk_on_termination = true
@@ -12,21 +12,24 @@ resource "azurerm_virtual_machine" "demo-instance" {
 
   storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
     version   = "latest"
   }
+
   storage_os_disk {
     name              = "myosdisk1"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
   }
+
   os_profile {
     computer_name  = "demo-instance"
     admin_username = "demo"
     #admin_password = "..."
   }
+
   os_profile_linux_config {
     disable_password_authentication = true
     ssh_keys {

--- a/first-steps/main.tf
+++ b/first-steps/main.tf
@@ -1,5 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+  }
 }
 
 # Create a resource group

--- a/for-foreach/instance.tf
+++ b/for-foreach/instance.tf
@@ -4,7 +4,7 @@ resource "azurerm_virtual_machine" "demo-instance" {
   location              = var.location
   resource_group_name   = azurerm_resource_group.demo.name
   network_interface_ids = [azurerm_network_interface.demo-instance.id]
-  vm_size               = "Standard_A1_v2"
+  vm_size               = "Standard_DC1s_v2"
 
   # this is a demo instance, so we can delete all data on termination
   delete_os_disk_on_termination = true
@@ -12,21 +12,24 @@ resource "azurerm_virtual_machine" "demo-instance" {
 
   storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
     version   = "latest"
   }
+
   storage_os_disk {
     name              = "myosdisk1"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
   }
+
   os_profile {
     computer_name  = "demo-instance"
     admin_username = "demo"
     #admin_password = "..."
   }
+
   os_profile_linux_config {
     disable_password_authentication = true
     ssh_keys {

--- a/for-foreach/main.tf
+++ b/for-foreach/main.tf
@@ -1,5 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+  }
 }
 
 # Create a resource group

--- a/kubernetes/main.tf
+++ b/kubernetes/main.tf
@@ -1,5 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+  }
 }
 
 # Create a resource group

--- a/network-security-groups/instance.tf
+++ b/network-security-groups/instance.tf
@@ -4,7 +4,7 @@ resource "azurerm_virtual_machine" "demo-instance-1" {
   location              = var.location
   resource_group_name   = azurerm_resource_group.demo.name
   network_interface_ids = [azurerm_network_interface.demo-instance-1.id]
-  vm_size               = "Standard_A1_v2"
+  vm_size               = "Standard_DC1s_v2"
 
   # this is a demo instance, so we can delete all data on termination
   delete_os_disk_on_termination = true
@@ -12,20 +12,24 @@ resource "azurerm_virtual_machine" "demo-instance-1" {
 
   storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
     version   = "latest"
   }
+
   storage_os_disk {
     name              = "myosdisk1"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
   }
+
   os_profile {
     computer_name  = "demo-instance"
     admin_username = "demo"
+    #admin_password = "..."
   }
+
   os_profile_linux_config {
     disable_password_authentication = true
     ssh_keys {

--- a/network-security-groups/main.tf
+++ b/network-security-groups/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+  }
 }

--- a/remote-state/instance.tf
+++ b/remote-state/instance.tf
@@ -4,7 +4,7 @@ resource "azurerm_virtual_machine" "demo-instance" {
   location              = var.location
   resource_group_name   = azurerm_resource_group.demo.name
   network_interface_ids = ["${azurerm_network_interface.demo-instance.id}"]
-  vm_size               = "Standard_A1_v2"
+  vm_size               = "Standard_DC1s_v2"
 
   # this is a demo instance, so we can delete all data on termination
   delete_os_disk_on_termination    = true
@@ -12,21 +12,24 @@ resource "azurerm_virtual_machine" "demo-instance" {
 
   storage_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
     version   = "latest"
   }
+
   storage_os_disk {
     name              = "myosdisk1"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
   }
+
   os_profile {
     computer_name  = "demo-instance"
     admin_username = "demo"
     #admin_password = "..."
   }
+
   os_profile_linux_config {
     disable_password_authentication = true
     ssh_keys {

--- a/remote-state/main.tf
+++ b/remote-state/main.tf
@@ -1,5 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+  }
 }
 
 # Create a resource group

--- a/resource-group/main.tf
+++ b/resource-group/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+  }
 }

--- a/streaming-analytics-iot/main.tf
+++ b/streaming-analytics-iot/main.tf
@@ -1,5 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.68.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  version = "=1.35.0"
+  features {
+  }
 }
 
 # Create a resource group


### PR DESCRIPTION
Hi @jornjambers @wardviaene great job on the course, thanks!

I made some changes, to get fellow students quicker on track, because it took me some time to proceed:
- Updated the providers to the new standard
- Updated the providers to always use the latest version
- Updated the instance to Ubuntu 22.04 LTS gen2 
- Changed to the smallest sku size which supports Ubuntu 22.04 LTS gen2, with in mind to reduce cost as much as possible but on the other hand have more security on the VM.