### PR TITLE
Changed application gateway deprecated sku to v2

### DIFF
--- a/application-gateway/.terraform.lock.hcl
+++ b/application-gateway/.terraform.lock.hcl
@@ -20,3 +20,22 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:3hjTP5tQBspPcFAJlfafnWrNrKnr7J4Cp0qB9jbqf30=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/application-gateway/app_gateway.tf
+++ b/application-gateway/app_gateway.tf
@@ -4,8 +4,8 @@ resource "azurerm_application_gateway" "app-gateway" {
   location            = var.location
 
   sku {
-    name     = "Standard_Small"
-    tier     = "Standard"
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
     capacity = 2
   }
 
@@ -46,6 +46,7 @@ resource "azurerm_application_gateway" "app-gateway" {
 
   request_routing_rule {
     name                       = "httpRoutingRule"
+    priority                   = 9
     rule_type                  = "Basic"
     http_listener_name         = "httpListener"
     backend_address_pool_name  = "BackEndAddressPool"
@@ -57,6 +58,7 @@ resource "azurerm_public_ip" "demo" {
   name                = "demo-public-ip"
   location            = var.location
   resource_group_name = azurerm_resource_group.demo.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
   domain_name_label   = azurerm_resource_group.demo.name
+  sku                 = "Standard"
 }

--- a/application-gateway/resourcegroup.tf
+++ b/application-gateway/resourcegroup.tf
@@ -1,4 +1,12 @@
+resource "random_string" "random-name" {
+  length  = 10
+  upper   = false
+  lower   = true
+  numeric = true
+  special = false
+}
+
 resource "azurerm_resource_group" "demo" {
-  name     = "application-gateway-demo"
+  name     = "application-gateway-demo-${random_string.random-name.result}"
   location = var.location
 }


### PR DESCRIPTION
Hi @wardviaene, the application gateway didn't deploy because the v1 sku size is deprecated, I have changed the following:
- Changed the sku size to the recommended Standard v2
- Changed the public ip from dynamic to static (this is required for the Standard v2 sku size).
- Added sku size to the public ip (this is required for the Standard v2 sku size).
- Added the priority to the routing rule
- Added random string to resource group name, because this is used to create a DNS record which needs to be unique